### PR TITLE
Getting version in a way that is backward-compatible with Ruby 1.8.x,…

### DIFF
--- a/lib/puppet/provider/package/composer.rb
+++ b/lib/puppet/provider/package/composer.rb
@@ -28,7 +28,7 @@ Puppet::Type.type(:package).provide :composer, :parent => Puppet::Provider::Pack
 
     output.lines.collect do |line|
       package = line[/^[a-z0-9]+\/[a-z0-9-]+\b/]
-      version = line[/(?<=\s|^)v?(?:\d+\.)+\d+(?:-(?:dev|alpha|beta|RC)\d*)?(?=\s|$)/]
+      version = line[/v?(?:\d+\.)+\d+(?:-(?:dev|alpha|beta|RC)\d*)?(?=\s|$)/]
 
       if package && version
         @composerlist[package] = version
@@ -58,7 +58,7 @@ Puppet::Type.type(:package).provide :composer, :parent => Puppet::Provider::Pack
     else
       version = :absent
     end
-    
+
     {:name => resource[:name], :ensure => version, :provider => 'composer'}
   end
 
@@ -69,7 +69,7 @@ Puppet::Type.type(:package).provide :composer, :parent => Puppet::Provider::Pack
       package = "#{resource[:name]}:#{resource[:ensure]}"
     end
 
-    begin      
+    begin
       composer(['global', 'require', '--no-interaction', package])
     rescue Puppet::ExecutionFailure => e
       if $CHILD_STATUS.exitstatus == 1 or e.message.include? 'Installation failed'


### PR DESCRIPTION
… so that the module will not break when used with puppet agents running on that ruby version.

My editor stripped some trailing whitespace on lines 61 and 72.  Sorry for the confusion.